### PR TITLE
Add check for FreeBSD to specify location for doctest

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,13 @@ executable('simplomon', 'simplomon.cc', 'notifiers.cc', 'minicurl.cc', 'dnsmon.c
 
 
 
-executable('testrunner', 'testrunner.cc', 'notifiers.cc', 'minicurl.cc', 'dnsmon.cc', 'record-types.cc', 'dnsmessages.cc', 'dns-storage.cc', 'netmon.cc', 'luabridge.cc',
-	dependencies: [doctest_dep, curl_dep, json_dep, fmt_dep, cpphttplib, 
-	simplesockets_dep, lua_dep])
+if host_machine.system() in ['freebsd']
+  incdir = include_directories('/usr/local/include/doctest')
+  executable('testrunner', 'testrunner.cc', 'notifiers.cc', 'minicurl.cc', 'dnsmon.cc', 'record-types.cc', 'dnsmessages.cc', 'dns-storage.cc', 'netmon.cc', 'luabridge.cc',
+        dependencies: [doctest_dep, curl_dep, json_dep, fmt_dep, cpphttplib, simplesockets_dep, lua_dep],
+        include_directories: incdir)
+else
+  executable('testrunner', 'testrunner.cc', 'notifiers.cc', 'minicurl.cc', 'dnsmon.cc', 'record-types.cc', 'dnsmessages.cc', 'dns-storage.cc', 'netmon.cc', 'luabridge.cc',
+        dependencies: [doctest_dep, curl_dep, json_dep, fmt_dep, cpphttplib, simplesockets_dep, lua_dep])
+endif
 


### PR DESCRIPTION
doctest isn't found on FreeBSD without specifying the directory it lives in. I don't know if this is required in other environments, so the if statement can be expanded as necessary. 

For this to work on FreeBSD, you will need to the doctest package (devel/doctest).

This addresses: https://github.com/berthubert/simplomon/issues/5