### PR TITLE
Add personalized chime capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Here are some sample checkers:
 ```lua
 dailyChime{utcHour=10} -- 10AM UTC chime confirms monitoring works
 
+-- or with a personalized chime message
+-- dailyChime{utcHour=10, content="goodmorning!"}
+
 -- the following checks certificates, and whines if any expire within
 -- two weeks
 https{url="https://berthub.eu"}


### PR DESCRIPTION
I'd like to see a different message every day, along the lines of:

```
-- 10AM UTC chime confirms monitoring works with random (hopefully interesting!) adage
fortune = assert(io.popen('/usr/games/fortune', 'r'))
fortune:flush()
dailyChime{utcHour=10, content=fortune:read('*all')}
fortune:close()
```