### PR TITLE
Fix compilation on 32-bit systems like armv7l

### DIFF
--- a/minicurl.hh
+++ b/minicurl.hh
@@ -49,7 +49,7 @@ public:
   std::string urlEncode(std::string_view str);
   CURL *d_curl;
   time_t d_filetime=-1;
-  int d_http_code=-1;
+  long d_http_code=-1;
 private:
   std::string d_data;
   static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdata);

--- a/minicurl.hh
+++ b/minicurl.hh
@@ -49,7 +49,7 @@ public:
   std::string urlEncode(std::string_view str);
   CURL *d_curl;
   time_t d_filetime=-1;
-  long d_http_code=-1;
+  int d_http_code=-1;
 private:
   std::string d_data;
   static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdata);

--- a/netmon.cc
+++ b/netmon.cc
@@ -214,7 +214,7 @@ CheckResult HTTPSChecker::perform()
       double httpMsec = dt.lapUsec()/1000.0;
       d_results[subject]["http-msec"]= roundDec(httpMsec, 1);
       d_results[subject]["msec"] = roundDec((ipv6 ? dnsMsec6 : dnsMsec4) + httpMsec, 1);
-      d_results[subject]["http-code"] = mc.d_http_code;
+      d_results[subject]["http-code"] = (int32_t)mc.d_http_code;
       
       if(mc.d_http_code >= 400) {
         cr.d_reasons[subject].push_back(fmt::format("Content {} generated a {} status code{}", d_url, mc.d_http_code, serverIP));

--- a/notifiers.cc
+++ b/notifiers.cc
@@ -163,7 +163,7 @@ void Notifier::bulkAlert(const std::string& textBody)
 void SQLiteWriterNotifier::alert(const std::string& str)
 {
   if(g_sqlw)
-    g_sqlw->addValue({{"tstamp", time(nullptr)}, {"message", str}}, "notifications");
+    g_sqlw->addValue({{"tstamp", (int64_t)time(nullptr)}, {"message", str}}, "notifications");
 }
 
 void Notifier::bulkDone()

--- a/simplomon.cc
+++ b/simplomon.cc
@@ -157,7 +157,7 @@ try
             out.push_back({"subject", r.first});
             for(const auto& res : r.second)
               out.push_back({res.first.c_str(), res.second});
-            out.push_back({"tstamp", time(nullptr)});
+            out.push_back({"tstamp", (int64_t)time(nullptr)});
             if(g_sqlw)
               g_sqlw->addValue(out, c->getCheckerName());
           }
@@ -190,7 +190,7 @@ try
             out.push_back({"checker", c->getCheckerName()});
             out.push_back({"subject", reason.first});
             out.push_back({"reason", r2});
-            out.push_back({"tstamp", time(nullptr)});
+            out.push_back({"tstamp", (int64_t)time(nullptr)});
             g_sqlw->addValue(out, "reports");
           }
         }


### PR DESCRIPTION
On some 32-bits targets with glibc, time_t still defaults to 32-bit (on armv7l: a `long`). Meanwhile, a `SQLiteWriter::var_t` can hold either an `int`, a `long long`, or a `long long unsigned`. Resolve this by casting to `int64_t`, which is a `long long`.

If compiled for targets where time_t is already a 64-bit integer, this has no effect.