### PR TITLE
Guard against multiple calls to Logger, Webserver

### DIFF
--- a/simplomon.cc
+++ b/simplomon.cc
@@ -19,7 +19,7 @@ vector<std::unique_ptr<Checker>> g_checkers;
 vector<std::shared_ptr<Notifier>> g_notifiers;
 std::optional<bool> g_haveIPv6;
 std::unique_ptr<SQLiteWriter> g_sqlw;
-
+bool g_web;
 
 /* the idea
    Every checker can generate multiple alerts.

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -292,6 +292,7 @@ private:
 extern std::vector<std::unique_ptr<Checker>> g_checkers;
 extern std::unique_ptr<SQLiteWriter> g_sqlw;
 extern std::optional<bool> g_haveIPv6;
+extern bool g_web;
 
 void checkLuaTable(sol::table data,
                    const std::set<std::string>& mandatory,


### PR DESCRIPTION
The configuration parser allows something like this:

```
Webserver{address="192.0.2.10:8080", user="api-access-for-robot", password="robot"}
Webserver{address="192.0.2.20:8090", user="dashboard-for-human", password="human"}
```

But the behavior is potentially unexpected:

- For Logger: the "last one wins".
- For Webserver: "both win" (you indeed get two endpoints) except that the username and password for both endpoints are taken from the last call.

This makes it so that any second call to Webserver or Logger is rejected.