### PR TITLE
Disable br, gzip compression support in cpp-httplib by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,7 @@ if not lua_dep.found()
     error('Lua 5.3 could not be found')
 endif
 
-cpphttplib = dependency('cpp-httplib')
+cpphttplib = dependency('cpp-httplib', default_options: ['cpp-httplib_zlib=disabled', 'cpp-httplib_brotli=disabled'])
 sqlitewriter_dep = dependency('sqlitewriter', static: true)
 doctest_dep=dependency('doctest')
 simplesockets_dep = dependency('simplesockets', static: true)


### PR DESCRIPTION
Fixes https://github.com/berthubert/simplomon/issues/14 and makes behavior more consistent between the `httpredir` and `https` checkers.

Since these are `default_options`, they "only have effect when Meson is run for the first time, and command line arguments override any default options in build files" [(ref)](https://mesonbuild.com/Reference-manual_functions.html#dependency_default_options).