### PR TITLE
Remove 'using namespace std;' from header, (re)move some unused includes

### DIFF
--- a/minicurl.cc
+++ b/minicurl.cc
@@ -23,6 +23,7 @@
  */
 
 #include "minicurl.hh"
+#include <atomic>
 #include <curl/curl.h>
 #include <stdexcept>
 #include <vector>

--- a/minicurl.hh
+++ b/minicurl.hh
@@ -27,8 +27,6 @@
 #include <curl/curl.h>
 #include "comboaddress.hh"
 #include <map>
-#include <atomic>
-#include <stdexcept>
 using std::string;
 // turns out 'CURL' is currently typedef for void which means we can't easily forward declare it
 

--- a/nenum.hh
+++ b/nenum.hh
@@ -1,10 +1,9 @@
 #pragma once
 #include <cstdint>
-#include <iostream>
+#include <cstring>
+#include <ostream>
 #include <stdexcept>
-#include <algorithm>
-#include <array>
-#include <string.h>
+#include <utility>
 
 #define SMARTENUMSTART(x) static constexpr std::pair<x, const char*> enumtypemap##x[]= {
 #define SENUM(x,a1) { x::a1, #a1},

--- a/notifiers.cc
+++ b/notifiers.cc
@@ -2,6 +2,7 @@
 #include "httplib.h"
 #include "nlohmann/json.hpp"
 #include "fmt/format.h"
+#include "sqlwriter.hh"
 
 #include "simplomon.hh"
 

--- a/notifiers.cc
+++ b/notifiers.cc
@@ -9,8 +9,8 @@
 PushoverNotifier::PushoverNotifier(sol::table data) : Notifier(data)
 {
   checkLuaTable(data, {"user", "apikey"});
-  d_user = data.get<string>("user");
-  d_apikey = data.get<string>("apikey");
+  d_user = data.get<std::string>("user");
+  d_apikey = data.get<std::string>("apikey");
   d_notifierName="PushOver";
 }
 
@@ -40,9 +40,9 @@ void PushoverNotifier::alert(const std::string& msg)
 NtfyNotifier::NtfyNotifier(sol::table data) : Notifier(data)
 {
   checkLuaTable(data, {"topic"}, {"auth", "url"});
-  d_auth = data.get_or("auth", string(""));
-  d_url = data.get_or("url", string("https://ntfy.sh"));
-  d_topic = data.get<string>("topic");
+  d_auth = data.get_or("auth", std::string(""));
+  d_url = data.get_or("url", std::string("https://ntfy.sh"));
+  d_topic = data.get<std::string>("topic");
   d_notifierName="Ntfy";
 }
 
@@ -78,7 +78,7 @@ static uint64_t getRandom64()
 static void sendAsciiEmailAsync(const std::string& server, const std::string& from, const std::string& to, const std::string& subject, const std::string& textBody)
 {
   const char* allowed="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_+-.@";
-  if(from.find_first_not_of(allowed) != string::npos || to.find_first_not_of(allowed) != string::npos) {
+  if(from.find_first_not_of(allowed) != std::string::npos || to.find_first_not_of(allowed) != std::string::npos) {
     throw std::runtime_error("Illegal character in from or to address");
   }
 
@@ -87,7 +87,7 @@ static void sendAsciiEmailAsync(const std::string& server, const std::string& fr
 
   SocketCommunicator sc(s);
   sc.connect(mailserver);
-  string line;
+  std::string line;
   auto sponge= [&](int expected) {
     while(sc.getLine(line)) {
       if(line.size() < 4)
@@ -121,7 +121,7 @@ static void sendAsciiEmailAsync(const std::string& server, const std::string& fr
   sc.writen(fmt::format("Date: {:%a, %d %b %Y %H:%M:%S %z (%Z)}\r\n", fmt::localtime(time(0))));
   sc.writen("\r\n");
 
-  string withCrlf;
+  std::string withCrlf;
   for(auto iter = textBody.cbegin(); iter != textBody.cend(); ++iter) {
     if(*iter=='\n' && (iter == textBody.cbegin() || *std::prev(iter)!='\r'))
       withCrlf.append(1, '\r');
@@ -139,9 +139,9 @@ static void sendAsciiEmailAsync(const std::string& server, const std::string& fr
 EmailNotifier::EmailNotifier(sol::table data) : Notifier(data)
 {
   checkLuaTable(data, {"from", "to", "server"});
-  d_from = data.get<string>("from");
-  d_to = data.get<string>("to");
-  d_server = ComboAddress(data.get<string>("server"), 25);
+  d_from = data.get<std::string>("from");
+  d_to = data.get<std::string>("to");
+  d_server = ComboAddress(data.get<std::string>("server"), 25);
   d_notifierName="Email";
 }
 
@@ -186,7 +186,7 @@ void Notifier::bulkDone()
                  inserter(diff, diff.begin()));
   //  fmt::print("{} alerts were resolved\n", diff.size());
 
-  map<string, time_t> deltime;
+  std::map<std::string, time_t> deltime;
   for(const auto& d : diff) {
     deltime[d] = d_times[d];
     d_times.erase(d);
@@ -212,7 +212,7 @@ void Notifier::bulkDone()
     
   //  fmt::print("got {} NEW results that are old enough\n", diff.size());
   for(const auto& str : diff) {
-    string desc = getAgeDesc(d_times[str]);
+    std::string desc = getAgeDesc(d_times[str]);
     //    fmt::print("Reporting {}\n", str);
     if(d_minMinutes)
       this->alert("("+desc+" already) " +str);
@@ -227,7 +227,7 @@ void Notifier::bulkDone()
   //  fmt::print("There are {} results that used to be old enough & are gone now\n",
   //         diff.size());
   for(const auto& str : diff) {
-    string desc = getAgeDesc(deltime[str]);
+    std::string desc = getAgeDesc(deltime[str]);
     this->alert(fmt::format("🎉 after {}, the following alert is over: {}",
                             desc,
                             str));
@@ -240,9 +240,9 @@ void Notifier::bulkDone()
 TelegramNotifier::TelegramNotifier(sol::table data) : Notifier(data) 
 { 
   checkLuaTable(data, {"bot_id", "apikey", "chat_id"});
-  d_botid = data.get<string>("bot_id");
-  d_apikey = data.get<string>("apikey");
-  d_chatid = data.get<string>("chat_id");
+  d_botid = data.get<std::string>("bot_id");
+  d_apikey = data.get<std::string>("apikey");
+  d_chatid = data.get<std::string>("chat_id");
 }
 
 void TelegramNotifier::alert(const std::string& message)

--- a/notifiers.hh
+++ b/notifiers.hh
@@ -1,10 +1,9 @@
 #pragma once
-#include <string>
 #include "sol/sol.hpp"
 #include "sclasses.hh"
+#include <map>
 #include <set>
-#include "sqlwriter.hh"
-#include "fmt/core.h"
+#include <string>
 
 class Notifier
 {
@@ -20,7 +19,6 @@ public:
 
   ~Notifier()
   {
-    //    fmt::print("A notifier was destroyed\n");
   }
   virtual void alert(const std::string& message) = 0;
   std::string getNotifierName() { return d_notifierName; }

--- a/simplomon.cc
+++ b/simplomon.cc
@@ -1,14 +1,11 @@
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 #include <map>
-#include <curl/curl.h>
 #include "notifiers.hh"
-#include "nlohmann/json.hpp"
 #include <unistd.h>
 #include <time.h>
 #include "minicurl.hh"
 #include <thread>
-#include <mutex>
 #include "simplomon.hh"
 #include "sqlwriter.hh"
 #include "sol/sol.hpp"

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -1,6 +1,8 @@
 #pragma once
+#include <map>
 #include <mutex>
 #include <string>
+#include <vector>
 #include "record-types.hh"
 #include "sclasses.hh"
 #include "notifiers.hh"
@@ -8,7 +10,6 @@
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
 #include "sqlwriter.hh"
-using namespace std;
 
 extern sol::state g_lua;
 
@@ -27,7 +28,7 @@ struct CheckResult
     if(reason.empty())
       d_reasons.clear();
   }
-  std::map<std::string,vector<std::string>> d_reasons;
+  std::map<std::string,std::vector<std::string>> d_reasons;
 };
 
 extern std::vector<std::shared_ptr<Notifier>> g_notifiers;
@@ -49,7 +50,7 @@ public:
     data["failureWindow"] = sol::lua_nil;
     // bake in
     //    fmt::print("Baking in {} notifiers\n", g_notifiers.size());
-    std::optional<vector<shared_ptr<Notifier>>> spec = data["notifiers"];
+    std::optional<std::vector<std::shared_ptr<Notifier>>> spec = data["notifiers"];
     if(spec) {
       //      fmt::print("Got {} specific notifiers\n", spec->size());
       notifiers.push_back(g_notifiers[0]);
@@ -97,9 +98,9 @@ struct CheckResultFilter
     reportResult(source, subject, cr, time(nullptr));
   }
 
-  std::set<pair<Checker*, std::string>> getFilteredResults();
+  std::set<std::pair<Checker*, std::string>> getFilteredResults();
 
-  std::map<Checker*, std::map<std::string, map<std::string, std::set<time_t>> >> d_reports;
+  std::map<Checker*, std::map<std::string, std::map<std::string, std::set<time_t>> >> d_reports;
   
   int d_maxseconds;
 };
@@ -154,7 +155,7 @@ public:
   std::string getCheckerName() override { return "dnssoa"; }
   std::string getDescription() override
   {
-    std::vector<string> servers;
+    std::vector<std::string> servers;
     for(const auto& s : d_servers) servers.push_back(s.toStringWithPort());
     return fmt::format("DNS SOA check, servers {}, domain {}",
                        servers, d_domain.toString());
@@ -176,7 +177,7 @@ public:
   std::string getCheckerName() override { return "tcpportclosed"; }
   std::string getDescription() override
   {
-    std::vector<string> servers;
+    std::vector<std::string> servers;
     for(const auto& s : d_servers) servers.push_back(s.toString());
     return fmt::format("TCP closed check, servers {}, ports {}",
                        servers, d_ports);
@@ -197,7 +198,7 @@ public:
   std::string getCheckerName() override { return "ping"; }
   std::string getDescription() override
   {
-    std::vector<string> servers;
+    std::vector<std::string> servers;
     for(const auto& s : d_servers) servers.push_back(s.toString());
     return fmt::format("PING check, servers {}", servers);
 
@@ -297,7 +298,7 @@ void checkLuaTable(sol::table data,
                    const std::set<std::string>& opt = std::set<std::string>());
 
 void startWebService(sol::table data);
-void giveToWebService(const std::set<pair<Checker*, std::string>>&,
+void giveToWebService(const std::set<std::pair<Checker*, std::string>>&,
                       const std::map<std::string, time_t>& startAlerts);
 void updateWebService();
 bool checkForWorkingIPv6();

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -5,7 +5,6 @@
 #include "sclasses.hh"
 #include "notifiers.hh"
 #include "sol/sol.hpp"
-#include "nlohmann/json.hpp"
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
 #include "sqlwriter.hh"


### PR DESCRIPTION
This PR removes `using namespace std;` from simplomon.hh so that .cc files that include that header can still decide for themselves what parts of the std namespace they want.

It also moves some #includes that can be in the .cc rather than the .hh, making it a bit faster to compile simplomon.