### PR TITLE
Add matching response body against a regex to https checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ https{url="https://galmon.eu/", method="HEAD"}
 -- This complains if that URL is older than 20 minutes
 https{url="https://berthub.eu/nlelec/dutch-stack.svg", maxAgeMinutes=20}
 
+-- check if the response body contains a regex match
+https{url="https://example.org", regex="[Ee]xample [Dd]omain"}
+
 -- check if a specific server IP is serving correctly
 https{url="https://berthub.eu", serverIP="86.82.68.237"}
 https{url="https://berthub.eu", serverIP="2001:41f0:782d::2"}

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include <mutex>
+#include <regex>
 #include <string>
 #include "record-types.hh"
 #include "sclasses.hh"
@@ -232,6 +233,8 @@ private:
   unsigned int d_minCertDays = 14;
   std::optional<ComboAddress> d_serverIP, d_localIP4, d_localIP6;
   std::vector<ComboAddress> d_dns;
+  std::string d_regexStr;
+  std::regex d_regex;
 
   std::string d_method;
   std::string d_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";


### PR DESCRIPTION
The checker now fails if the response body does not contain a match for the given regular expression. This uses the default std::regex grammar ("modified ECMAScript"), with default options (so case sensitive).

If `minBytes` and `regex` are both given, `minBytes` is checked first. It is allowed, but probably not that useful, to combine `regex` and `method="HEAD"` for the same checker.

Issue #20 is related, but this does not add anything related to reading local files. It could, if the libcurl configuration was changed to allow the FILE 'protocol'...

```lua
https{url="file:///etc/resolv.conf", regex="nameserver 127.0.0.1"}
```

...but at that point, the name `https` for this checker would be a bit confusing.