### PR TITLE
Add virtual destructors to Checker and Notifier base classes

### DIFF
--- a/notifiers.hh
+++ b/notifiers.hh
@@ -17,11 +17,7 @@ public:
   Notifier(bool)
   {
   }
-
-  ~Notifier()
-  {
-    //    fmt::print("A notifier was destroyed\n");
-  }
+  virtual ~Notifier() = default;
   virtual void alert(const std::string& message) = 0;
   std::string getNotifierName() { return d_notifierName; }
   void bulkAlert(const std::string& textBody);

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -65,6 +65,7 @@ public:
     //  fmt::print("Adding notifier {}\n", n->getNotifierName());
   }
   Checker(const Checker&) = delete;
+  virtual ~Checker() = default;
   void Perform()
   {
     d_reasons = this->perform();


### PR DESCRIPTION
Checkers are kept in a `vector<unique_ptr<Checker>>`. If they were ever removed from that vector, they would be deleted through a base pointer. Since the different Checker subclasses have different fields and sizes, those would then not be correctly cleaned up.

The `Notifier` base class is then changed for consistency.