### PR TITLE
Fix local4/local6 typo in sendQuery leading to UB

### DIFF
--- a/support.cc
+++ b/support.cc
@@ -20,7 +20,7 @@ static DNSMessageReader sendQuery(const vector<ComboAddress>& resolvers, DNSName
           SBind(sock, *local4);
         }
         if(server.sin4.sin_family == AF_INET6 && local6) {
-          local4->setPort(0);
+          local6->setPort(0);
           SBind(sock, *local6);
         }
 


### PR DESCRIPTION
Before this fix, if only a local IPv6 address was given, an attempt would be made to reset the port on the nonexistent local IPv4 address. The intended reset would be missed, so the following (nonsense) config...

```lua
https{url="https://example.com", dns={"::1"}, localIP6="[::1]:8282"}
```

...would first hit UB and then (if that had no effect) consistently send the DNS question from port 8282.