### PR TITLE
Add virtual destructor to PromCheck base class

### DIFF
--- a/simplomon.hh
+++ b/simplomon.hh
@@ -256,6 +256,7 @@ private:
 
 struct PromCheck
 {
+  virtual ~PromCheck() = default;
   virtual void doCheck(CheckResult& cr, const PrometheusParser::prom_t & prom, const std::string& id,
                        std::map<std::string, std::map<std::string, SQLiteWriter::var_t>>& results) = 0;
 };


### PR DESCRIPTION
Similar to #33; since these are kept in a `std::vector<std::unique_ptr<PromCheck>>`, they need to be able to be deleted through a base pointer.