### PR TITLE
 https: New option to validate, CertSignature 

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -126,6 +126,14 @@ Here are the parameters, of which only `url` is mandatory:
    HEAD, possibly because of "web firewalls"
  * dns: get the IP address from these nameservers. Useful when testing
    against DNS-based CDNs (like Akamai). 
+ * CertPubKey: Remote certificate public key. If set, the checker will alert
+   if the public key of the certificate does not match this value.
+   Format is tuples divided by colon, where is first tuple is the
+   key type (RSA, ECDSA), remaining tuples depend on the key type. For RSA
+   keys, the second tuple is the exponent, the third tuple is the modulus (both in hex).
+   For example:
+   CertPubKey="RSA:10001:HEXLONGSTRING"
+
 
 ## imap
 The imap checker assumes it connects to a TLS endpoint. There it will check the certificate for freshness. 

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -239,6 +239,7 @@ private:
 
   std::string d_method;
   std::string d_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
+  std::string d_cert_pubkey;
 };
 
 


### PR DESCRIPTION
This option validates signature of remote certificate.
It is always possible that malicious actor might put MITM
node and obtain his own certificate.
In fact such attack already happened, one of well documented cases:
https://notes.valdikss.org.ru/jabber.ru-mitm/
The only way to detect such malicious intent is by validating
certificate signature.