### PR TITLE
Add Slack notifier support

### DIFF
--- a/luabridge.cc
+++ b/luabridge.cc
@@ -144,6 +144,14 @@ void initLua()
     return make_shared<NtfyNotifier>(data);
   });
 
+  g_lua.set_function("addSlackNotifier", [&](sol::table data) {
+    g_notifiers.emplace_back(make_shared<SlackNotifier>(data));
+    return *g_notifiers.rbegin();
+  });
+  g_lua.set_function("createSlackNotifier", [&](sol::table data) {
+    return make_shared<SlackNotifier>(data);
+  });
+
   g_lua.set_function("addEmailNotifier", [&](sol::table data) {
     g_notifiers.emplace_back(make_shared<EmailNotifier>(data));
     return *g_notifiers.rbegin();

--- a/manual.md
+++ b/manual.md
@@ -228,6 +228,13 @@ addNtfyNotifier{topic="your_secret_topic"}
 ```
 You can also specify an authorization through `auth`, and a notification URL through `url`.
 
+## Slack
+Example:
+
+```lua
+addSlackNotifier{auth="your_token", channel="your_channel"}
+```
+
 ## Pushover
 Example:
 ```lua

--- a/notifiers.hh
+++ b/notifiers.hh
@@ -78,6 +78,15 @@ private:
   std::string d_auth, d_url, d_topic;
 };
 
+class SlackNotifier : public Notifier
+{
+public:
+  SlackNotifier(sol::table data);
+  void alert(const std::string& message) override;
+private:
+  std::string d_auth, d_channel;
+};
+
 class EmailNotifier : public Notifier
 {
 public:


### PR DESCRIPTION
This pull request adds support for Slack as one of the notifiers alongside email, Telegram, Ntfy.sh, etc. The Slack API itself is documented here: https://api.slack.com/methods/chat.postMessage

When an alert comes in it looks like this:
![image](https://github.com/user-attachments/assets/5e3481ea-a4cb-40cd-a589-08c36c939c62)

Feel free to change whatever you like. I tried to follow the style of the other notifiers as much as possible, but I never do anything with C++ so I might be completely oblivious to some sins I am committing :-)


