### PR TITLE
Add support for external commands as checks

### DIFF
--- a/luabridge.cc
+++ b/luabridge.cc
@@ -119,6 +119,9 @@ void initLua()
     g_checkers.emplace_back(make_unique<PrometheusChecker>(data));
   });
   
+  g_lua.set_function("external", [&](sol::table data) {
+    g_checkers.emplace_back(make_unique<ExternalChecker>(data));
+  });
 
   g_lua.set_function("smtp", [&](sol::table data) {
     g_checkers.emplace_back(make_unique<SMTPChecker>(data));

--- a/netmon.cc
+++ b/netmon.cc
@@ -539,7 +539,7 @@ std::pair<int, std::string> exec(const char* cmd) {
     std::string result = "";
     int rc;
     FILE* pipe = popen(cmd, "r");
-    if (!pipe) throw std::runtime_error("popen() failed!");
+    if (!pipe) return std::pair<int, std::string> (255, "");
     try {
         while (fgets(buffer, sizeof buffer, pipe) != NULL) {
             result += buffer;

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -215,6 +215,23 @@ private:
 };
 
 
+class ExternalChecker : public Checker
+{
+public:
+  ExternalChecker(sol::table data);
+  CheckResult perform() override;
+  std::string getCheckerName() override { return "external"; }
+  std::string getDescription() override
+  {
+    return fmt::format("External check {} using expression {}", d_cmd, d_exp);
+  }
+
+private:
+  std::string d_cmd;
+  std::string d_exp;
+};
+
+
 class HTTPSChecker : public Checker
 {
 public:

--- a/simplomon.hh
+++ b/simplomon.hh
@@ -223,12 +223,13 @@ public:
   std::string getCheckerName() override { return "external"; }
   std::string getDescription() override
   {
-    return fmt::format("External check {} using expression {}", d_cmd, d_exp);
+    return fmt::format("External check {}", d_cmd);
   }
 
 private:
   std::string d_cmd;
   std::string d_exp;
+  int d_rc;
 };
 
 


### PR DESCRIPTION
Simplomon can monitor a lot, but not _everything_, which makes sense. This PR adds an `external` check (e.g. `external{cmd="do-thing", regex="success"}` or `external{cmd="do-other-thing", rc=0}`) to have a catch-all for checks that don't exist natively in Simplomon (in our case they are DANE validity checks).